### PR TITLE
Update Hyphenator.js

### DIFF
--- a/Hyphenator.js
+++ b/Hyphenator.js
@@ -451,7 +451,7 @@ Hyphenator = (function (window) {
                             computedHeight = shadow.offsetHeight;
                             //remove shadow element
                             bdy.removeChild(shadow);
-                            r = !!(computedHeight > 12);
+                            r = !!(computedHeight > 12 && shadow.style.hyphens == 'auto');
                             supportedBrowserLangs[lang] = r;
                         } else {
                             r = false;


### PR DESCRIPTION
New Chrome and Chromium support partial hyphens but this checks fails and don't hyphenate at all. After adding style for hyphens it is immediately removed but language support checker thinks that it is set. This bug occur when 'useCSS3hyphenation' is set to true.